### PR TITLE
passing 'migrating: true' to sails when lifting

### DIFF
--- a/lib/gruntTasks.js
+++ b/lib/gruntTasks.js
@@ -67,6 +67,7 @@ module.exports = function (grunt) {
     var done = this.async();
     var name = grunt.option('name');
     var sails;
+    var sailsConfig;
     var args;
     var env;
 
@@ -83,11 +84,18 @@ module.exports = function (grunt) {
       env = process.env.NODE_ENV;
     }
 
+    sailsConfig = {
+      port: -1,
+      log: { level: 'silent' },
+      environment: env,
+      migrating: true
+    };
+
     // lift Sails to get the effective configuration. We don't actually need to
     // run it, and we certainly don't want any log messages. We just want the
     // config.
     sails = new Sails();
-    sails.lift({ port: -1, log: { level: 'silent' }, environment: env }, function (err) {
+    sails.lift(sailsConfig, function (err) {
       var url;
 
       if (err) {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.3.1",
   "description": "db-migrate integration for sails.js",
   "main": "index.js",
-  "scripts": {
-    "test": "mocha"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/building5/sails-db-migrate.git"


### PR DESCRIPTION
Some applications may have logic they need to skip when the application is lifting solely to get the migration data, so this configuration key will be available to the application when a migration is taking place.
