### PR TITLE
Adding support for url field in connection

### DIFF
--- a/lib/sailsDbMigrate.js
+++ b/lib/sailsDbMigrate.js
@@ -27,7 +27,7 @@ function buildURL(connection) {
   }
 
   // return the connection url if one is configured
-  if(connection.url){
+  if (connection.url) {
     return connection.url;
   }
 


### PR DESCRIPTION
sails-postgresql and sails-mysql both have the option of specifying the connection using connection.url, rather than connection.host, connection.database, etc. This just adds support for that if it is present.
