### PR TITLE
update db-migrate peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mocha": "^1.21.4"
   },
   "peerDependencies": {
-    "db-migrate": "^0.7.1",
+    "db-migrate": "^0.8.0",
     "sails": "^0.10.4"
   }
 }


### PR DESCRIPTION
db-migrate 0.8.0 includes some changes we want (like better dry-run support) so updating this here so sails-db-migrate doesn't throw a peer dependency error with an updated db-migrate as a peer
