### PR TITLE
added --migrations-dir cli option mapping

### DIFF
--- a/lib/gruntTasks.js
+++ b/lib/gruntTasks.js
@@ -35,6 +35,11 @@ function buildDbMigrateArgs(grunt, command) {
   if (grunt.option('db-verbose')) {
     args.push('--verbose');
   }
+  
+  if (grunt.option('migrations-dir')) {
+    args.push('--migrations-dir');
+    args.push(grunt.option('migrations-dir'));
+  }
 
   return args;
 }


### PR DESCRIPTION
simple add to allow mapping of the migrations dir.  I have multiple environments and mapping the directory allows for use with that.  Also, it's a native option in node-db-migrate that was an easy map through