### PR TITLE
Adding table parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ module.exports.migrations = {
 };
 ```
 
+Optionally, you can specify in the config file the name of the database table to
+be used to track migrations (defaults to `migrations`), the directory to use for
+migrations (defaults to `migrations`), and whether to create a coffeescript
+file for the migrations instead of javascript file (defaults to `false`).
+
+```JavaScript
+// config/migrations.js
+module.exports.migrations = {
+  // connection name matches a field from config/connections.js
+  connection: 'somePostgresqlServer', // or MySQL
+  table: 'sails_migrations',
+  migrationsDir: 'sails_migrations',
+  coffeeFile: true
+};
+```
+
 You'll also need to setup `tasks/register/dbMigrate.js` to add the `db:migrate`
 tasks to grunt.
 

--- a/lib/gruntTasks.js
+++ b/lib/gruntTasks.js
@@ -10,7 +10,7 @@ var sailsDbMigrate = require('./sailsDbMigrate');
  * @param command The db-migrate command to run.
  * @returns Arguments array for the db-migrate command.
  */
-function buildDbMigrateArgs(grunt, command) {
+function buildDbMigrateArgs(grunt, config, command) {
   var args = [];
   var name = grunt.option('name');
 
@@ -37,16 +37,29 @@ function buildDbMigrateArgs(grunt, command) {
   }
 
   if (grunt.option('sql-file')) {
-    args.push('--sql-file')
+    args.push('--sql-file');
   }
 
   if (grunt.option('coffee-file')) {
-    args.push('--coffee-file')
+    args.push('--coffee-file');
+  } else if (config.coffeeFile) {
+    args.push('--coffee-file');
   }
-  
+
   if (grunt.option('migrations-dir')) {
     args.push('--migrations-dir');
     args.push(grunt.option('migrations-dir'));
+  } else if (config.migrationsDir) {
+    args.push('--migrations-dir');
+    args.push(config.migrationsDir);
+  }
+
+  if (grunt.option('table')) {
+    args.push('--table');
+    args.push(grunt.option('table'));
+  } else if (config.table) {
+    args.push('--table');
+    args.push(config.table);
   }
 
   return args;
@@ -65,11 +78,15 @@ function usage(grunt) {
   grunt.log.writeln('  --name=NAME  Name of the migration to create');
   grunt.log.writeln();
   grunt.log.writeln('db:migrate[:up|:down] Options:');
-  grunt.log.writeln('  --count=N      Max number of migrations to run.');
-  grunt.log.writeln('  --dry-run      Prints the SQL but doesn\'t run it.');
-  grunt.log.writeln('  --db-verbose   Verbose mode.');
-  grunt.log.writeln('  --sql-file     Create sql files for up and down.');
-  grunt.log.writeln('  --coffee-file  Create a coffeescript migration file.');
+  grunt.log.writeln('  --count=N         Max number of migrations to run.');
+  grunt.log.writeln('  --dry-run         Prints the SQL but doesn\'t run it.');
+  grunt.log.writeln('  --db-verbose      Verbose mode.');
+  grunt.log.writeln('  --sql-file        Create sql files for up and down.');
+  grunt.log.writeln('  --coffee-file     Create a coffeescript migration file.');
+  grunt.log.writeln('  --migrations-dir  The directory to use for migration files.');
+  grunt.log.writeln('                    Defaults to "migrations".');
+  grunt.log.writeln('  --table           Specify the table to track migrations in.');
+  grunt.log.writeln('                    Defaults to "migrations".');
 }
 
 /**
@@ -83,15 +100,12 @@ module.exports = function (grunt) {
     var name = grunt.option('name');
     var sails;
     var sailsConfig;
-    var args;
     var env;
 
     if (!command) {
       usage(grunt);
       return done();
     }
-
-    args = buildDbMigrateArgs(grunt, command);
 
     if (grunt.option('env')){
       env = grunt.option('env');
@@ -112,6 +126,7 @@ module.exports = function (grunt) {
     sails = new Sails();
     sails.lift(sailsConfig, function (err) {
       var url;
+      var args = buildDbMigrateArgs(grunt, sails.config.migrations, command);
 
       if (err) {
         grunt.fail.fatal('Could not lift sails', err);


### PR DESCRIPTION
This is just scratching a small itch, we needed to use a specific migration table name, which `node-db-migrate` originally allowed but `sails-db-migrate` doesn't.  Can be set as a config file option or as a command line parameter (per the original).