### PR TITLE
Compatibility for sails js v1

### DIFF
--- a/lib/sailsDbMigrate.js
+++ b/lib/sailsDbMigrate.js
@@ -82,7 +82,7 @@ function parseSailsConfig(sailsConfig) {
     throw new Error('connection missing from ./config/migrations.js');
   }
 
-  connection = sailsConfig.connections[connectionName];
+  connection = sailsConfig.datastores[connectionName];
 
   if (!connection) {
     throw new Error('could not find connection ' + connectionName + ' in ./config/connections.js');


### PR DESCRIPTION
**WHY ?**

Sails v1 didn't use `config/connections.js` anymore so move to new `config/datastores.js`

**HOW ?**

Only change the key call when parsing config connection datas.

**TODO**

Maybe, it could be tag it as 2.0.0-beta if you want please, I use my patch until anofficial tag will be created.